### PR TITLE
Add a composite action

### DIFF
--- a/.github/bad-composite-action/action.yml
+++ b/.github/bad-composite-action/action.yml
@@ -1,0 +1,16 @@
+name: "Failed Custom Composite Action"
+description: "This action tries to access secrets in the caller workflow. It's not going to work."
+
+runs:
+  # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-composite-actions
+  using: "composite" # Required You must set this value to 'composite'
+  steps:
+    # This step throws error. It tries to access secrets in the caller workflow. It's not going to work.
+    - name: "Failed to access secret"
+      run: echo "Try to access SECRET0:${{secrets.SECRET0}}"
+      shell: bash
+
+    # Also not working for GITHUB_TOKEN
+    - name: "Try to access GITHUB_TOKEN"
+      run: echo "${{secrets.GITHUB_TOKEN}}"
+      shell: bash

--- a/.github/composite-action/action.yml
+++ b/.github/composite-action/action.yml
@@ -1,0 +1,57 @@
+name: "Custom Composite Action"
+description: "The filename must be action.yml"
+
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
+inputs:
+  input1:
+    description: "The first input to composite action"
+    required: true
+
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions
+outputs:
+  composite-action-out1:
+    description: "The first output from composite action"
+    value: ${{steps.step-singleline.outputs.output1}}
+  composite-action-out2:
+    description: "The second output from reuse-workflow"
+    value: ${{steps.step-multiline.outputs.output2}}
+
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-actions
+runs:
+  # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-composite-actions
+  using: "composite" # Required You must set this value to 'composite'
+  steps:
+    - name: "Print input"
+      run: echo "input1 is:${{inputs.input1}}"
+      shell: bash
+
+    # - name: "Try to access secret"
+    #   run: echo "Try to access SECRET0:${{secrets.SECRET0}}"
+    #   shell: bash
+
+    # - name: "Try to access GITHUB_TOKEN"
+    #   run: echo "${{secrets.GITHUB_TOKEN}}"
+    #   shell: bash
+
+    - name: "Try to access env variable in the caller workflow"
+      run: echo "Try to access env vars in the caller workdlow:${{env.CALLER_ENV}}"
+      shell: bash
+
+    - name: "Try to access env variable assigned to this action"
+      run: echo "Try to access env vars in the assigned to this action:${{env.ASSIGNED_ENV}}"
+      shell: bash
+
+    - name: "assign single-line output"
+      id: step-singleline
+      run: echo "output1=single-line-outpu1-from-composite-action" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: "Dump multi-line output"
+      id: step-multiline
+      shell: bash
+      run: |
+        {
+          echo 'output2<<EOF'
+          curl https://example.com
+          echo EOF
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/driver-failed.yml
+++ b/.github/workflows/driver-failed.yml
@@ -1,0 +1,31 @@
+name: "Bad composite actions trying to access secrets in the caller workflow"
+
+on: 
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CALLER_ENV: "---"
+
+jobs:
+  use-failed-composite-action:
+    name: Use Composite Action in the same Repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: First step is just a warm greeting
+        run: echo "Hi"
+
+      - name: Access secrets in the caller workflow
+        run: echo "SECRET0 is:${{secrets.SECRET0}}"
+
+      # This step throws error. It tries to access secrets in the caller workflow. It's not going to work.
+      - name: Use composite action
+        id: composite-action
+        uses: ./.github/bad-composite-action
+        env:
+          ASSIGNED_ENV: "---"
+        with:
+          input1: "An input assigned to composite actions"

--- a/.github/workflows/driver.yml
+++ b/.github/workflows/driver.yml
@@ -1,0 +1,37 @@
+name: Use composite action in the same repo
+
+on: 
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CALLER_ENV: "An environment variable in the caller workflow."
+
+jobs:
+  use-composite-action:
+    name: Use Composite Action in the same Repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: First step is just a warm greeting
+        run: echo "Hi"
+
+      - name: Access secrets in the caller workflow
+        run: echo "SECRET0 is:${{secrets.SECRET0}}"
+
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-an-action-in-the-same-repository-as-the-workflow
+      - name: Use composite action
+        id: composite-action
+        uses: ./.github/composite-action
+        env:
+          ASSIGNED_ENV: "An environment variable assigned to composite actions"
+        with:
+          input1: "An input assigned to composite actions"
+
+      - name: Print the single-line from the composite action
+        run: echo "The single-line output is:${{steps.composite-action.outputs.composite-action-out1}}"
+
+      - name: Print the multi-line from the composite action
+        run: echo 'The multi-line output is:${{steps.composite-action.outputs.composite-action-out2}}'


### PR DESCRIPTION
Composite Actions: 
- `./github/composite-action/composite-action`: How to use inputs/output/environment variables in github action
- `./github/bad-composite-action`: Breaks github action by trying to access secrets in composite actions

Workflows using composite actions:
- `./github/workflows/driver.yml`: How to use composite actions in the same repo. How to pass inputs and use outputs.
- `./github/workflows/driver-failed.yml`: It's just not working because of the bad composite action.